### PR TITLE
Expose ID generator

### DIFF
--- a/lib/bundler/sbom/spdx.rb
+++ b/lib/bundler/sbom/spdx.rb
@@ -6,7 +6,7 @@ module Bundler
   module Sbom
     class SPDX
       def self.generate(lockfile, document_name)
-        spdx_id = SecureRandom.uuid
+        spdx_id = generate_spdx_id
         sbom = {
           "SPDXID" => "SPDXRef-DOCUMENT",
           "spdxVersion" => "SPDX-2.3",
@@ -67,39 +67,39 @@ module Bundler
       def self.to_xml(sbom)
         doc = REXML::Document.new
         doc << REXML::XMLDecl.new("1.0", "UTF-8")
-        
+
         # Root element
         root = REXML::Element.new("SpdxDocument")
         root.add_namespace("https://spdx.org/spdxdocs/")
         doc.add_element(root)
-        
+
         # Document info
         add_element(root, "SPDXID", sbom["SPDXID"])
         add_element(root, "spdxVersion", sbom["spdxVersion"])
         add_element(root, "name", sbom["name"])
         add_element(root, "dataLicense", sbom["dataLicense"])
         add_element(root, "documentNamespace", sbom["documentNamespace"])
-        
+
         # Creation info
         creation_info = REXML::Element.new("creationInfo")
         root.add_element(creation_info)
         add_element(creation_info, "created", sbom["creationInfo"]["created"])
         add_element(creation_info, "licenseListVersion", sbom["creationInfo"]["licenseListVersion"])
-        
+
         sbom["creationInfo"]["creators"].each do |creator|
           add_element(creation_info, "creator", creator)
         end
-        
+
         # Describes
         sbom["documentDescribes"].each do |describes|
           add_element(root, "documentDescribes", describes)
         end
-        
+
         # Packages
         sbom["packages"].each do |pkg|
           package = REXML::Element.new("package")
           root.add_element(package)
-          
+
           add_element(package, "SPDXID", pkg["SPDXID"])
           add_element(package, "name", pkg["name"])
           add_element(package, "versionInfo", pkg["versionInfo"])
@@ -109,20 +109,20 @@ module Bundler
           add_element(package, "licenseDeclared", pkg["licenseDeclared"])
           add_element(package, "copyrightText", pkg["copyrightText"])
           add_element(package, "supplier", pkg["supplier"])
-          
+
           # External references
           if pkg["externalRefs"]
             pkg["externalRefs"].each do |ref|
               ext_ref = REXML::Element.new("externalRef")
               package.add_element(ext_ref)
-              
+
               add_element(ext_ref, "referenceCategory", ref["referenceCategory"])
               add_element(ext_ref, "referenceType", ref["referenceType"])
               add_element(ext_ref, "referenceLocator", ref["referenceLocator"])
             end
           end
         end
-        
+
         formatter = REXML::Formatters::Pretty.new(2)
         formatter.compact = true
         output = ""
@@ -132,7 +132,7 @@ module Bundler
 
       def self.parse_xml(doc)
         root = doc.root
-        
+
         sbom = {
           "SPDXID" => get_element_text(root, "SPDXID"),
           "spdxVersion" => get_element_text(root, "spdxVersion"),
@@ -147,17 +147,17 @@ module Bundler
           "packages" => [],
           "documentDescribes" => []
         }
-        
+
         # Collect creators
         REXML::XPath.each(root, "creationInfo/creator") do |creator|
           sbom["creationInfo"]["creators"] << creator.text
         end
-        
+
         # Collect documentDescribes
         REXML::XPath.each(root, "documentDescribes") do |describes|
           sbom["documentDescribes"] << describes.text
         end
-        
+
         # Collect packages
         REXML::XPath.each(root, "package") do |pkg_element|
           package = {
@@ -172,7 +172,7 @@ module Bundler
             "supplier" => get_element_text(pkg_element, "supplier"),
             "externalRefs" => []
           }
-          
+
           # Collect external references
           REXML::XPath.each(pkg_element, "externalRef") do |ref_element|
             ref = {
@@ -182,10 +182,10 @@ module Bundler
             }
             package["externalRefs"] << ref
           end
-          
+
           sbom["packages"] << package
         end
-        
+
         sbom
       end
 
@@ -203,14 +203,16 @@ module Bundler
         }
       end
 
-      private
-      
+      def self.generate_spdx_id
+        SecureRandom.uuid
+      end
+
       def self.add_element(parent, name, value)
         element = REXML::Element.new(name)
         element.text = value
         parent.add_element(element)
       end
-      
+
       def self.get_element_text(element, xpath)
         result = REXML::XPath.first(element, xpath)
         result ? result.text : nil


### PR DESCRIPTION
We have integrated this into our build pipeline (thank you!) but it generates an unstable ID so we get diffs with every spec build.

We'd like to be able to expose (and thus override/monkey patch) in a stable id generator in our specs. We also freeze time with Timecop to stabilise the timestamp.

Does that make sense? Would you recommend doing something else?