### PR TITLE
SPDX 2.3: drop XML, add DEPENDS_ON, derive licenseListVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ Available options:
 - `--without GROUPS`: Exclude groups (comma or colon separated, e.g., 'development:test' or 'development,test')
 
 Generated files will be named according to the following pattern:
-- SPDX format: `bom.json` or `bom.xml`
+- SPDX format: `bom.json`
 - CycloneDX format: `bom-cyclonedx.json` or `bom-cyclonedx.xml`
 
 Examples:
 ```
 $ bundle sbom dump                           # Generates SPDX format in JSON (bom.json)
-$ bundle sbom dump -f xml                    # Generates SPDX format in XML (bom.xml)
 $ bundle sbom dump -s cyclonedx             # Generates CycloneDX format in JSON (bom-cyclonedx.json)
 $ bundle sbom dump -s cyclonedx -f xml      # Generates CycloneDX format in XML (bom-cyclonedx.xml)
 $ bundle sbom dump --without development    # Excludes development group
@@ -52,10 +51,9 @@ Available options:
 - `-F, --format FORMAT`: Input format (json or xml)
 
 If no options are specified, the command will automatically look for SBOM files in the following order:
-1. `bom.xml` (if format is xml)
+1. `bom.json`
 2. `bom-cyclonedx.json`
 3. `bom-cyclonedx.xml`
-4. `bom.json`
 
 This command will show:
 - A count of packages using each license
@@ -69,8 +67,10 @@ Note: The `license` command requires that you've already generated the SBOM usin
 [SPDX (Software Package Data Exchange)](https://spdx.dev/) is a standard format for communicating software bill of material information, including components, licenses, copyrights, and security references.
 
 - Spec version: [SPDX 2.3](https://spdx.github.io/spdx-spec/v2.3/)
-- Output formats: JSON, XML
+- Output formats: JSON
 - License identifiers are validated against the [SPDX License List](https://spdx.org/licenses/) via the `spdx-licenses` gem. Non-SPDX licenses are output as `LicenseRef-` identifiers, and deprecated SPDX IDs (e.g., `GPL-2.0`) are mapped to their current equivalents (e.g., `GPL-2.0-only`).
+- `DEPENDS_ON` relationships between packages are emitted from `Gemfile.lock`.
+- `creationInfo.licenseListVersion` reflects the SPDX license list version bundled with the `spdx-licenses` gem.
 
 ### CycloneDX (v1.4)
 [CycloneDX](https://cyclonedx.org/) is a lightweight SBOM specification designed for use in application security contexts and supply chain component analysis.

--- a/lib/bundler/sbom/cli.rb
+++ b/lib/bundler/sbom/cli.rb
@@ -22,6 +22,10 @@ module Bundler
           raise Thor::Error, "Error: Unsupported SBOM format '#{sbom_format}'. Supported formats: spdx, cyclonedx"
         end
 
+        if sbom_format == "spdx" && format == "xml"
+          raise Thor::Error, "Error: SPDX 2.3 does not define an XML serialization. Use '--format json' or '--sbom cyclonedx --format xml'."
+        end
+
         generator = Bundler::Sbom::Generator.new(format: sbom_format, without_groups: without_groups)
         sbom = generator.generate
 
@@ -50,8 +54,8 @@ module Bundler
         end
 
         if input_file.nil?
-          input_file = if format == "xml" || (format.nil? && File.exist?("bom.xml"))
-            "bom.xml"
+          input_file = if File.exist?("bom.json")
+            "bom.json"
           elsif File.exist?("bom-cyclonedx.json")
             "bom-cyclonedx.json"
           elsif File.exist?("bom-cyclonedx.xml")

--- a/lib/bundler/sbom/generator.rb
+++ b/lib/bundler/sbom/generator.rb
@@ -42,7 +42,7 @@ module Bundler
         if root.name == "bom" && root.namespace.include?("cyclonedx.org")
           CycloneDX.parse_xml(doc)
         else
-          SPDX.parse_xml(doc)
+          raise ArgumentError, "Unsupported XML SBOM: only CycloneDX XML can be read"
         end
       end
 
@@ -93,8 +93,18 @@ module Bundler
           gem_key = "#{spec.name}:#{spec.version}"
           next if seen.include?(gem_key)
           seen.add(gem_key)
-          {name: spec.name, version: spec.version.to_s, licenses: SpecLicenseFinder.find_licenses(spec)}
+          {
+            name: spec.name,
+            version: spec.version.to_s,
+            licenses: SpecLicenseFinder.find_licenses(spec),
+            dependencies: spec_dependency_names(spec)
+          }
         end
+      end
+
+      def spec_dependency_names(spec)
+        return [] unless spec.respond_to?(:dependencies) && spec.dependencies
+        spec.dependencies.reject { |d| d.respond_to?(:type) && d.type == :development }.map(&:name)
       end
     end
   end

--- a/lib/bundler/sbom/spdx.rb
+++ b/lib/bundler/sbom/spdx.rb
@@ -15,8 +15,7 @@ module Bundler
           "spdxVersion" => "SPDX-2.3",
           "creationInfo" => {
             "created" => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "creators" => ["Tool: bundle-sbom"],
-            "licenseListVersion" => "3.20"
+            "creators" => ["Tool: bundle-sbom"]
           },
           "name" => document_name,
           "dataLicense" => "CC0-1.0",
@@ -24,12 +23,21 @@ module Bundler
           "packages" => []
         }
 
+        if (list_version = license_list_version)
+          sbom["creationInfo"]["licenseListVersion"] = list_version
+        end
+
+        package_ids = {}
+        gem_data.each do |gem|
+          package_ids[gem[:name]] = "SPDXRef-Package-#{gem[:name]}"
+        end
+
         gem_data.each do |gem|
           spdx_licenses = gem[:licenses].map { |l| normalize_license_id(l) }
           license_string = spdx_licenses.empty? ? "NOASSERTION" : spdx_licenses.join(" AND ")
 
           package = {
-            "SPDXID" => "SPDXRef-Package-#{gem[:name]}",
+            "SPDXID" => package_ids[gem[:name]],
             "name" => gem[:name],
             "versionInfo" => gem[:version],
             "downloadLocation" => "https://rubygems.org/gems/#{gem[:name]}/versions/#{gem[:version]}",
@@ -50,6 +58,7 @@ module Bundler
         end
 
         sbom["documentDescribes"] = sbom["packages"].map { |p| p["SPDXID"] }
+
         sbom["relationships"] = sbom["packages"].map do |p|
           {
             "spdxElementId" => "SPDXRef-DOCUMENT",
@@ -57,138 +66,20 @@ module Bundler
             "relationshipType" => "DESCRIBES"
           }
         end
-        new(sbom)
-      end
 
-      def self.parse_xml(doc)
-        root = doc.root
-
-        sbom = {
-          "SPDXID" => get_element_text(root, "SPDXID"),
-          "spdxVersion" => get_element_text(root, "spdxVersion"),
-          "name" => get_element_text(root, "name"),
-          "dataLicense" => get_element_text(root, "dataLicense"),
-          "documentNamespace" => get_element_text(root, "documentNamespace"),
-          "creationInfo" => {
-            "created" => get_element_text(root, "creationInfo/created"),
-            "licenseListVersion" => get_element_text(root, "creationInfo/licenseListVersion"),
-            "creators" => []
-          },
-          "packages" => [],
-          "documentDescribes" => [],
-          "relationships" => []
-        }
-
-        REXML::XPath.each(root, "creationInfo/creator") do |creator|
-          sbom["creationInfo"]["creators"] << creator.text
-        end
-
-        REXML::XPath.each(root, "documentDescribes") do |describes|
-          sbom["documentDescribes"] << describes.text
-        end
-
-        REXML::XPath.each(root, "package") do |pkg_element|
-          package = {
-            "SPDXID" => get_element_text(pkg_element, "SPDXID"),
-            "name" => get_element_text(pkg_element, "name"),
-            "versionInfo" => get_element_text(pkg_element, "versionInfo"),
-            "downloadLocation" => get_element_text(pkg_element, "downloadLocation"),
-            "filesAnalyzed" => get_element_text(pkg_element, "filesAnalyzed") == "true",
-            "licenseConcluded" => get_element_text(pkg_element, "licenseConcluded"),
-            "licenseDeclared" => get_element_text(pkg_element, "licenseDeclared"),
-            "copyrightText" => get_element_text(pkg_element, "copyrightText"),
-            "supplier" => get_element_text(pkg_element, "supplier"),
-            "externalRefs" => []
-          }
-
-          REXML::XPath.each(pkg_element, "externalRef") do |ref_element|
-            ref = {
-              "referenceCategory" => get_element_text(ref_element, "referenceCategory"),
-              "referenceType" => get_element_text(ref_element, "referenceType"),
-              "referenceLocator" => get_element_text(ref_element, "referenceLocator")
+        gem_data.each do |gem|
+          (gem[:dependencies] || []).each do |dep_name|
+            dep_id = package_ids[dep_name]
+            next unless dep_id
+            sbom["relationships"] << {
+              "spdxElementId" => package_ids[gem[:name]],
+              "relatedSpdxElement" => dep_id,
+              "relationshipType" => "DEPENDS_ON"
             }
-            package["externalRefs"] << ref
           end
-
-          sbom["packages"] << package
-        end
-
-        REXML::XPath.each(root, "relationship") do |rel_element|
-          sbom["relationships"] << {
-            "spdxElementId" => get_element_text(rel_element, "spdxElementId"),
-            "relatedSpdxElement" => get_element_text(rel_element, "relatedSpdxElement"),
-            "relationshipType" => get_element_text(rel_element, "relationshipType")
-          }
         end
 
         new(sbom)
-      end
-
-      def to_xml
-        doc = REXML::Document.new
-        doc << REXML::XMLDecl.new("1.0", "UTF-8")
-
-        root = REXML::Element.new("SpdxDocument")
-        root.add_namespace("https://spdx.org/spdxdocs/")
-        doc.add_element(root)
-
-        add_element(root, "SPDXID", @data["SPDXID"])
-        add_element(root, "spdxVersion", @data["spdxVersion"])
-        add_element(root, "name", @data["name"])
-        add_element(root, "dataLicense", @data["dataLicense"])
-        add_element(root, "documentNamespace", @data["documentNamespace"])
-
-        creation_info = REXML::Element.new("creationInfo")
-        root.add_element(creation_info)
-        add_element(creation_info, "created", @data["creationInfo"]["created"])
-        add_element(creation_info, "licenseListVersion", @data["creationInfo"]["licenseListVersion"])
-
-        @data["creationInfo"]["creators"].each do |creator|
-          add_element(creation_info, "creator", creator)
-        end
-
-        @data["documentDescribes"].each do |describes|
-          add_element(root, "documentDescribes", describes)
-        end
-
-        @data["packages"].each do |pkg|
-          package = REXML::Element.new("package")
-          root.add_element(package)
-
-          add_element(package, "SPDXID", pkg["SPDXID"])
-          add_element(package, "name", pkg["name"])
-          add_element(package, "versionInfo", pkg["versionInfo"])
-          add_element(package, "downloadLocation", pkg["downloadLocation"])
-          add_element(package, "filesAnalyzed", pkg["filesAnalyzed"].to_s)
-          add_element(package, "licenseConcluded", pkg["licenseConcluded"])
-          add_element(package, "licenseDeclared", pkg["licenseDeclared"])
-          add_element(package, "copyrightText", pkg["copyrightText"])
-          add_element(package, "supplier", pkg["supplier"])
-
-          if pkg["externalRefs"]
-            pkg["externalRefs"].each do |ref|
-              ext_ref = REXML::Element.new("externalRef")
-              package.add_element(ext_ref)
-
-              add_element(ext_ref, "referenceCategory", ref["referenceCategory"])
-              add_element(ext_ref, "referenceType", ref["referenceType"])
-              add_element(ext_ref, "referenceLocator", ref["referenceLocator"])
-            end
-          end
-        end
-
-        if @data["relationships"]
-          @data["relationships"].each do |rel|
-            relationship = REXML::Element.new("relationship")
-            root.add_element(relationship)
-
-            add_element(relationship, "spdxElementId", rel["spdxElementId"])
-            add_element(relationship, "relatedSpdxElement", rel["relatedSpdxElement"])
-            add_element(relationship, "relationshipType", rel["relationshipType"])
-          end
-        end
-
-        format_xml(doc)
       end
 
       DEPRECATED_LICENSE_MAP = {
@@ -198,8 +89,6 @@ module Bundler
         "LGPL-2.1" => "LGPL-2.1-only",
         "LGPL-3.0" => "LGPL-3.0-only",
       }.freeze
-
-      private
 
       def self.normalize_license_id(license_id)
         if mapped = DEPRECATED_LICENSE_MAP[license_id]
@@ -216,7 +105,15 @@ module Bundler
       end
       private_class_method :normalize_license_id
 
-      public
+      def self.license_list_version
+        return @license_list_version if defined?(@license_list_version)
+        gem_spec = Gem.loaded_specs["spdx-licenses"]
+        path = File.join(gem_spec.full_gem_path, "licenses.json")
+        @license_list_version = JSON.parse(File.read(path))["licenseListVersion"]
+      rescue StandardError
+        @license_list_version = nil
+      end
+      private_class_method :license_list_version
 
       def to_report_format
         {

--- a/test/bundler/sbom/test_cli.rb
+++ b/test/bundler/sbom/test_cli.rb
@@ -62,28 +62,14 @@ class Bundler::Sbom::CLITest < Minitest::Test
     assert_match(/Generated SPDX SBOM at bom\.json/, out)
   end
 
-  def test_dump_xml_format_generates_spdx_xml
-    spdx_instance = Bundler::Sbom::SPDX.new(sample_spdx_sbom)
-    xml_output = "<xml>spdx</xml>"
-    spdx_instance.define_singleton_method(:to_xml) { xml_output }
-
-    received_args = nil
-    fake_new = proc do |**kwargs|
-      received_args = kwargs
-      mock_gen = Minitest::Mock.new
-      mock_gen.expect(:generate, spdx_instance)
-      mock_gen
+  def test_dump_xml_format_with_spdx_exits
+    _, err = capture_io do
+      assert_raises(SystemExit) do
+        Bundler::Sbom::CLI.start(%w[dump --format xml])
+      end
     end
-
-    out = nil
-    Bundler::Sbom::Generator.stub(:new, fake_new) do
-      out, = capture_io { Bundler::Sbom::CLI.start(%w[dump --format xml]) }
-    end
-
-    assert_equal({format: "spdx", without_groups: []}, received_args)
-    assert File.exist?("bom.xml"), "bom.xml should be created"
-    assert_equal xml_output, File.read("bom.xml")
-    assert_match(/Generated SPDX SBOM at bom\.xml/, out)
+    assert_match(/SPDX 2.3 does not define an XML serialization/, err)
+    refute File.exist?("bom.xml")
   end
 
   def test_dump_cyclonedx_json
@@ -299,40 +285,20 @@ class Bundler::Sbom::CLITest < Minitest::Test
     assert_match(/License Usage in SBOM/, out)
   end
 
-  def test_license_reads_xml_format
-    spdx_xml = <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <SpdxDocument xmlns="https://spdx.org/spdxdocs/">
-        <SPDXID>SPDXRef-DOCUMENT</SPDXID>
-        <spdxVersion>SPDX-2.3</spdxVersion>
-        <name>test-project</name>
-        <dataLicense>CC0-1.0</dataLicense>
-        <documentNamespace>https://spdx.org/spdxdocs/test-project-123</documentNamespace>
-        <creationInfo>
-          <created>2023-01-01T12:00:00Z</created>
-          <creator>Tool: bundle-sbom</creator>
-          <licenseListVersion>3.20</licenseListVersion>
-        </creationInfo>
-        <package>
-          <SPDXID>SPDXRef-Package-rake</SPDXID>
-          <name>rake</name>
-          <versionInfo>13.0.6</versionInfo>
-          <licenseDeclared>MIT</licenseDeclared>
-        </package>
-      </SpdxDocument>
-    XML
-    File.write("bom.xml", spdx_xml)
-
-    out, = capture_io { Bundler::Sbom::CLI.start(%w[license --format xml]) }
-    assert_match(/License Usage in SBOM/, out)
-  end
-
   def test_license_xml_invalid_exits
-    File.write("bom.xml", "<invalid>XML Content")
+    File.write("bom-cyclonedx.xml", "<invalid>XML Content")
 
     assert_raises(SystemExit) do
-      capture_io { Bundler::Sbom::CLI.start(%w[license --format xml]) }
+      capture_io { Bundler::Sbom::CLI.start(%w[license]) }
     end
+  end
+
+  def test_license_prefers_bom_json_over_cyclonedx
+    File.write("bom.json", JSON.generate(sample_spdx_sbom))
+    File.write("bom-cyclonedx.json", JSON.generate(sample_cyclonedx_sbom))
+
+    out, = capture_io { Bundler::Sbom::CLI.start(%w[license]) }
+    assert_match(/License Usage in SBOM/, out)
   end
 
   def test_license_with_specific_file_path

--- a/test/bundler/sbom/test_generator.rb
+++ b/test/bundler/sbom/test_generator.rb
@@ -74,16 +74,18 @@ class Bundler::Sbom::GeneratorTest < Minitest::Test
     spec
   end
 
-  def make_spec(name, version)
+  def make_spec(name, version, dependencies: [])
     s = Object.new
     s.define_singleton_method(:name) { name }
     s.define_singleton_method(:version) { Gem::Version.new(version) }
+    s.define_singleton_method(:dependencies) { dependencies.map { |d| Gem::Dependency.new(d) } }
     s
   end
 
-  def make_lockfile_parser(specs)
+  def make_lockfile_parser(specs, dependencies: {})
     parser = Object.new
     parser.define_singleton_method(:specs) { specs }
+    parser.define_singleton_method(:dependencies) { dependencies }
     parser
   end
 
@@ -347,6 +349,19 @@ class Bundler::Sbom::GeneratorTest < Minitest::Test
     end
   end
 
+  def test_generate_spdx_captures_dependency_graph_from_lockfile
+    specs = [
+      make_spec("actionpack", "7.0.0", dependencies: ["rack"]),
+      make_spec("rack", "3.0.0")
+    ]
+
+    stub_lockfile_and_gems(specs, default: nil) do
+      sbom = Bundler::Sbom::Generator.new.generate
+      depends_on = sbom.to_hash["relationships"].select { |r| r["relationshipType"] == "DEPENDS_ON" }
+      assert_equal [{"spdxElementId" => "SPDXRef-Package-actionpack", "relatedSpdxElement" => "SPDXRef-Package-rack", "relationshipType" => "DEPENDS_ON"}], depends_on
+    end
+  end
+
   # -- CycloneDX format tests --
 
   def test_generate_cyclonedx_document
@@ -479,67 +494,6 @@ class Bundler::Sbom::GeneratorTest < Minitest::Test
     end
   end
 
-  # -- to_xml SPDX --
-
-  def test_spdx_to_xml
-    sbom_hash = {
-      "SPDXID" => "SPDXRef-DOCUMENT",
-      "spdxVersion" => "SPDX-2.3",
-      "name" => "test-project",
-      "dataLicense" => "CC0-1.0",
-      "documentNamespace" => "https://spdx.org/spdxdocs/test-project-123",
-      "creationInfo" => {
-        "created" => "2023-01-01T12:00:00Z",
-        "creators" => ["Tool: bundle-sbom"],
-        "licenseListVersion" => "3.20"
-      },
-      "documentDescribes" => ["SPDXRef-Package-rake"],
-      "packages" => [
-        {
-          "SPDXID" => "SPDXRef-Package-rake",
-          "name" => "rake",
-          "versionInfo" => "13.0.6",
-          "downloadLocation" => "NOASSERTION",
-          "filesAnalyzed" => false,
-          "licenseConcluded" => "MIT",
-          "licenseDeclared" => "MIT",
-          "copyrightText" => "NOASSERTION",
-          "supplier" => "NOASSERTION",
-          "externalRefs" => [
-            {
-              "referenceCategory" => "PACKAGE-MANAGER",
-              "referenceType" => "purl",
-              "referenceLocator" => "pkg:gem/rake@13.0.6"
-            }
-          ]
-        }
-      ]
-    }
-
-    sbom = Bundler::Sbom::SPDX.new(sbom_hash)
-    xml_content = sbom.to_xml
-    assert_kind_of String, xml_content
-    assert_includes xml_content, '<?xml version="1.0" encoding="UTF-8"?>'
-
-    doc = REXML::Document.new(xml_content)
-    root = doc.root
-
-    assert_equal "SpdxDocument", root.name
-    assert_equal "SPDXRef-DOCUMENT", REXML::XPath.first(root, "SPDXID").text
-    assert_equal "SPDX-2.3", REXML::XPath.first(root, "spdxVersion").text
-    assert_equal "test-project", REXML::XPath.first(root, "name").text
-
-    package = REXML::XPath.first(root, "package")
-    refute_nil package
-    assert_equal "rake", REXML::XPath.first(package, "name").text
-    assert_equal "13.0.6", REXML::XPath.first(package, "versionInfo").text
-    assert_equal "MIT", REXML::XPath.first(package, "licenseDeclared").text
-
-    ext_ref = REXML::XPath.first(package, "externalRef")
-    refute_nil ext_ref
-    assert_equal "pkg:gem/rake@13.0.6", REXML::XPath.first(ext_ref, "referenceLocator").text
-  end
-
   # -- to_xml CycloneDX --
 
   def test_cyclonedx_to_xml
@@ -626,70 +580,18 @@ class Bundler::Sbom::GeneratorTest < Minitest::Test
     assert_includes license_ids, "Apache-2.0"
   end
 
-  # -- parse_xml SPDX --
+  # -- parse_xml rejects non-CycloneDX --
 
-  def test_parse_xml_spdx
+  def test_parse_xml_rejects_non_cyclonedx
     xml_content = <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
-      <SpdxDocument xmlns="https://spdx.org/spdxdocs/">
-        <SPDXID>SPDXRef-DOCUMENT</SPDXID>
-        <spdxVersion>SPDX-2.3</spdxVersion>
-        <name>test-project</name>
-        <dataLicense>CC0-1.0</dataLicense>
-        <documentNamespace>https://spdx.org/spdxdocs/test-project-123</documentNamespace>
-        <creationInfo>
-          <created>2023-01-01T12:00:00Z</created>
-          <creator>Tool: bundle-sbom</creator>
-          <licenseListVersion>3.20</licenseListVersion>
-        </creationInfo>
-        <documentDescribes>SPDXRef-Package-rake</documentDescribes>
-        <package>
-          <SPDXID>SPDXRef-Package-rake</SPDXID>
-          <name>rake</name>
-          <versionInfo>13.0.6</versionInfo>
-          <downloadLocation>NOASSERTION</downloadLocation>
-          <filesAnalyzed>false</filesAnalyzed>
-          <licenseConcluded>MIT</licenseConcluded>
-          <licenseDeclared>MIT</licenseDeclared>
-          <copyrightText>NOASSERTION</copyrightText>
-          <supplier>NOASSERTION</supplier>
-          <externalRef>
-            <referenceCategory>PACKAGE-MANAGER</referenceCategory>
-            <referenceType>purl</referenceType>
-            <referenceLocator>pkg:gem/rake@13.0.6</referenceLocator>
-          </externalRef>
-        </package>
-      </SpdxDocument>
+      <SpdxDocument xmlns="https://spdx.org/spdxdocs/"/>
     XML
 
-    sbom = Bundler::Sbom::Generator.parse_xml(xml_content)
-
-    assert_kind_of Bundler::Sbom::SPDX, sbom
-    assert_equal "SPDXRef-DOCUMENT", sbom.to_hash["SPDXID"]
-    assert_equal "SPDX-2.3", sbom.to_hash["spdxVersion"]
-    assert_equal "test-project", sbom.to_hash["name"]
-    assert_equal "CC0-1.0", sbom.to_hash["dataLicense"]
-
-    assert_kind_of Hash, sbom.to_hash["creationInfo"]
-    assert_equal "2023-01-01T12:00:00Z", sbom.to_hash["creationInfo"]["created"]
-    assert_includes sbom.to_hash["creationInfo"]["creators"], "Tool: bundle-sbom"
-
-    assert_kind_of Array, sbom.to_hash["packages"]
-    assert_equal 1, sbom.to_hash["packages"].size
-
-    package = sbom.to_hash["packages"].first
-    assert_equal "SPDXRef-Package-rake", package["SPDXID"]
-    assert_equal "rake", package["name"]
-    assert_equal "13.0.6", package["versionInfo"]
-    assert_equal "MIT", package["licenseDeclared"]
-
-    assert_kind_of Array, package["externalRefs"]
-    assert_equal 1, package["externalRefs"].size
-
-    ext_ref = package["externalRefs"].first
-    assert_equal "PACKAGE-MANAGER", ext_ref["referenceCategory"]
-    assert_equal "purl", ext_ref["referenceType"]
-    assert_equal "pkg:gem/rake@13.0.6", ext_ref["referenceLocator"]
+    err = assert_raises(ArgumentError) do
+      Bundler::Sbom::Generator.parse_xml(xml_content)
+    end
+    assert_match(/only CycloneDX XML/, err.message)
   end
 
   # -- parse_xml CycloneDX --

--- a/test/bundler/sbom/test_spdx.rb
+++ b/test/bundler/sbom/test_spdx.rb
@@ -1,6 +1,5 @@
 require "test_helper"
 require "bundler/lockfile_parser"
-require "rexml/document"
 
 class Bundler::Sbom::SPDXTest < Minitest::Test
   include TestHelper
@@ -63,7 +62,7 @@ class Bundler::Sbom::SPDXTest < Minitest::Test
     gem_data = [{name: "rake", version: "13.0.6", licenses: ["MIT"]}]
     sbom = Bundler::Sbom::SPDX.generate(gem_data, "test-project")
 
-    relationships = sbom.to_hash["relationships"]
+    describes = sbom.to_hash["relationships"].select { |r| r["relationshipType"] == "DESCRIBES" }
     expected = [
       {
         "spdxElementId" => "SPDXRef-DOCUMENT",
@@ -71,7 +70,46 @@ class Bundler::Sbom::SPDXTest < Minitest::Test
         "relationshipType" => "DESCRIBES"
       }
     ]
-    assert_equal expected, relationships
+    assert_equal expected, describes
+  end
+
+  def test_generate_includes_depends_on_relationships
+    gem_data = [
+      {name: "actionpack", version: "7.0.0", licenses: ["MIT"], dependencies: ["rack", "activesupport"]},
+      {name: "rack", version: "3.0.0", licenses: ["MIT"], dependencies: []},
+      {name: "activesupport", version: "7.0.0", licenses: ["MIT"], dependencies: ["tzinfo"]},
+      {name: "tzinfo", version: "2.0.6", licenses: ["MIT"], dependencies: []}
+    ]
+    sbom = Bundler::Sbom::SPDX.generate(gem_data, "test-project")
+
+    depends_on = sbom.to_hash["relationships"].select { |r| r["relationshipType"] == "DEPENDS_ON" }
+
+    expected = [
+      {"spdxElementId" => "SPDXRef-Package-actionpack", "relatedSpdxElement" => "SPDXRef-Package-rack", "relationshipType" => "DEPENDS_ON"},
+      {"spdxElementId" => "SPDXRef-Package-actionpack", "relatedSpdxElement" => "SPDXRef-Package-activesupport", "relationshipType" => "DEPENDS_ON"},
+      {"spdxElementId" => "SPDXRef-Package-activesupport", "relatedSpdxElement" => "SPDXRef-Package-tzinfo", "relationshipType" => "DEPENDS_ON"}
+    ]
+    assert_equal expected.sort_by { |r| [r["spdxElementId"], r["relatedSpdxElement"]] },
+                 depends_on.sort_by { |r| [r["spdxElementId"], r["relatedSpdxElement"]] }
+  end
+
+  def test_generate_depends_on_ignores_unknown_names
+    gem_data = [
+      {name: "foo", version: "1.0.0", licenses: [], dependencies: ["bar", "missing"]},
+      {name: "bar", version: "2.0.0", licenses: [], dependencies: []}
+    ]
+    sbom = Bundler::Sbom::SPDX.generate(gem_data, "test-project")
+
+    depends_on = sbom.to_hash["relationships"].select { |r| r["relationshipType"] == "DEPENDS_ON" }
+    assert_equal [{"spdxElementId" => "SPDXRef-Package-foo", "relatedSpdxElement" => "SPDXRef-Package-bar", "relationshipType" => "DEPENDS_ON"}], depends_on
+  end
+
+  def test_generate_license_list_version_from_gem
+    sbom = Bundler::Sbom::SPDX.generate([], "test-project")
+    version = sbom.to_hash["creationInfo"]["licenseListVersion"]
+    refute_nil version
+    assert_match(/\A\d+\.\d+/, version)
+    refute_equal "3.20", version
   end
 
   def test_generate_handles_multiple_licenses
@@ -116,155 +154,9 @@ class Bundler::Sbom::SPDXTest < Minitest::Test
     assert_equal "NOASSERTION", package["licenseDeclared"]
   end
 
-  # -- #to_xml --
-
-  def test_to_xml
-    sbom_hash = {
-      "SPDXID" => "SPDXRef-DOCUMENT",
-      "spdxVersion" => "SPDX-2.3",
-      "name" => "test-project",
-      "dataLicense" => "CC0-1.0",
-      "documentNamespace" => "https://spdx.org/spdxdocs/test-project-123",
-      "creationInfo" => {
-        "created" => "2023-01-01T12:00:00Z",
-        "creators" => ["Tool: bundle-sbom"],
-        "licenseListVersion" => "3.20"
-      },
-      "documentDescribes" => ["SPDXRef-Package-rake"],
-      "relationships" => [
-        {
-          "spdxElementId" => "SPDXRef-DOCUMENT",
-          "relatedSpdxElement" => "SPDXRef-Package-rake",
-          "relationshipType" => "DESCRIBES"
-        }
-      ],
-      "packages" => [
-        {
-          "SPDXID" => "SPDXRef-Package-rake",
-          "name" => "rake",
-          "versionInfo" => "13.0.6",
-          "downloadLocation" => "NOASSERTION",
-          "filesAnalyzed" => false,
-          "licenseConcluded" => "MIT",
-          "licenseDeclared" => "MIT",
-          "copyrightText" => "NOASSERTION",
-          "supplier" => "NOASSERTION",
-          "externalRefs" => [
-            {
-              "referenceCategory" => "PACKAGE-MANAGER",
-              "referenceType" => "purl",
-              "referenceLocator" => "pkg:gem/rake@13.0.6"
-            }
-          ]
-        }
-      ]
-    }
-
-    sbom = Bundler::Sbom::SPDX.new(sbom_hash)
-    xml_content = sbom.to_xml
-    assert_kind_of String, xml_content
-    assert_includes xml_content, '<?xml version="1.0" encoding="UTF-8"?>'
-
-    doc = REXML::Document.new(xml_content)
-    root = doc.root
-
-    assert_equal "SpdxDocument", root.name
-    assert_equal "SPDXRef-DOCUMENT", REXML::XPath.first(root, "SPDXID").text
-    assert_equal "SPDX-2.3", REXML::XPath.first(root, "spdxVersion").text
-    assert_equal "test-project", REXML::XPath.first(root, "name").text
-
-    package = REXML::XPath.first(root, "package")
-    refute_nil package
-    assert_equal "rake", REXML::XPath.first(package, "name").text
-    assert_equal "13.0.6", REXML::XPath.first(package, "versionInfo").text
-    assert_equal "MIT", REXML::XPath.first(package, "licenseDeclared").text
-
-    ext_ref = REXML::XPath.first(package, "externalRef")
-    refute_nil ext_ref
-    assert_equal "pkg:gem/rake@13.0.6", REXML::XPath.first(ext_ref, "referenceLocator").text
-
-    rel = REXML::XPath.first(root, "relationship")
-    refute_nil rel
-    assert_equal "SPDXRef-DOCUMENT", REXML::XPath.first(rel, "spdxElementId").text
-    assert_equal "SPDXRef-Package-rake", REXML::XPath.first(rel, "relatedSpdxElement").text
-    assert_equal "DESCRIBES", REXML::XPath.first(rel, "relationshipType").text
-  end
-
-  # -- .parse_xml --
-
-  def test_parse_xml
-    xml_content = <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <SpdxDocument xmlns="https://spdx.org/spdxdocs/">
-        <SPDXID>SPDXRef-DOCUMENT</SPDXID>
-        <spdxVersion>SPDX-2.3</spdxVersion>
-        <name>test-project</name>
-        <dataLicense>CC0-1.0</dataLicense>
-        <documentNamespace>https://spdx.org/spdxdocs/test-project-123</documentNamespace>
-        <creationInfo>
-          <created>2023-01-01T12:00:00Z</created>
-          <creator>Tool: bundle-sbom</creator>
-          <licenseListVersion>3.20</licenseListVersion>
-        </creationInfo>
-        <documentDescribes>SPDXRef-Package-rake</documentDescribes>
-        <package>
-          <SPDXID>SPDXRef-Package-rake</SPDXID>
-          <name>rake</name>
-          <versionInfo>13.0.6</versionInfo>
-          <downloadLocation>NOASSERTION</downloadLocation>
-          <filesAnalyzed>false</filesAnalyzed>
-          <licenseConcluded>MIT</licenseConcluded>
-          <licenseDeclared>MIT</licenseDeclared>
-          <copyrightText>NOASSERTION</copyrightText>
-          <supplier>NOASSERTION</supplier>
-          <externalRef>
-            <referenceCategory>PACKAGE-MANAGER</referenceCategory>
-            <referenceType>purl</referenceType>
-            <referenceLocator>pkg:gem/rake@13.0.6</referenceLocator>
-          </externalRef>
-        </package>
-        <relationship>
-          <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
-          <relatedSpdxElement>SPDXRef-Package-rake</relatedSpdxElement>
-          <relationshipType>DESCRIBES</relationshipType>
-        </relationship>
-      </SpdxDocument>
-    XML
-
-    doc = REXML::Document.new(xml_content)
-    sbom = Bundler::Sbom::SPDX.parse_xml(doc)
-
-    assert_kind_of Bundler::Sbom::SPDX, sbom
-    assert_equal "SPDXRef-DOCUMENT", sbom.to_hash["SPDXID"]
-    assert_equal "SPDX-2.3", sbom.to_hash["spdxVersion"]
-    assert_equal "test-project", sbom.to_hash["name"]
-    assert_equal "CC0-1.0", sbom.to_hash["dataLicense"]
-
-    assert_kind_of Hash, sbom.to_hash["creationInfo"]
-    assert_equal "2023-01-01T12:00:00Z", sbom.to_hash["creationInfo"]["created"]
-    assert_includes sbom.to_hash["creationInfo"]["creators"], "Tool: bundle-sbom"
-
-    assert_kind_of Array, sbom.to_hash["packages"]
-    assert_equal 1, sbom.to_hash["packages"].size
-
-    package = sbom.to_hash["packages"].first
-    assert_equal "SPDXRef-Package-rake", package["SPDXID"]
-    assert_equal "rake", package["name"]
-    assert_equal "13.0.6", package["versionInfo"]
-    assert_equal "MIT", package["licenseDeclared"]
-
-    assert_kind_of Array, package["externalRefs"]
-    assert_equal 1, package["externalRefs"].size
-
-    ext_ref = package["externalRefs"].first
-    assert_equal "PACKAGE-MANAGER", ext_ref["referenceCategory"]
-    assert_equal "purl", ext_ref["referenceType"]
-    assert_equal "pkg:gem/rake@13.0.6", ext_ref["referenceLocator"]
-
-    relationships = sbom.to_hash["relationships"]
-    assert_equal 1, relationships.size
-    assert_equal "SPDXRef-DOCUMENT", relationships.first["spdxElementId"]
-    assert_equal "SPDXRef-Package-rake", relationships.first["relatedSpdxElement"]
-    assert_equal "DESCRIBES", relationships.first["relationshipType"]
+  def test_spdx_does_not_support_xml
+    sbom = Bundler::Sbom::SPDX.generate([], "test-project")
+    refute_respond_to sbom, :to_xml
+    refute_respond_to Bundler::Sbom::SPDX, :parse_xml
   end
 end

--- a/test/bundler/sbom/test_spdx_schema_validation.rb
+++ b/test/bundler/sbom/test_spdx_schema_validation.rb
@@ -59,4 +59,14 @@ class SPDXSchemaValidationTest < Minitest::Test
     errors = schema.validate(sbom.to_hash).to_a
     assert_empty errors, errors.map { |e| "#{e["data_pointer"]}: #{e["type"]}" }.join("\n")
   end
+
+  def test_valid_spdx_document_with_dependencies
+    gem_data = [
+      {name: "actionpack", version: "7.0.0", licenses: ["MIT"], dependencies: ["rack"]},
+      {name: "rack", version: "3.0.0", licenses: ["MIT"], dependencies: []}
+    ]
+    sbom = Bundler::Sbom::SPDX.generate(gem_data, "test-project")
+    errors = schema.validate(sbom.to_hash).to_a
+    assert_empty errors, errors.map { |e| "#{e["data_pointer"]}: #{e["type"]}" }.join("\n")
+  end
 end


### PR DESCRIPTION
A few fixes to the SPDX 2.3 output.

- Removed the SPDX XML serialization. SPDX 2.3 does not define an XML format and the `<SpdxDocument>` output was not readable by any SPDX tooling. `bundle sbom dump -s spdx -f xml` now errors with guidance, and `bundle sbom license` no longer auto-detects `bom.xml`.
- `DEPENDS_ON` relationships are emitted between packages based on `Gemfile.lock`.
- `creationInfo.licenseListVersion` is read from the `licenses.json` shipped with the `spdx-licenses` gem instead of a hardcoded `3.20`.
- Tidied the `private`/`public` keywords around `normalize_license_id` that had no effect.